### PR TITLE
Fix invalid buffer length in logFormat()

### DIFF
--- a/src/asmjit/base/logger.cpp
+++ b/src/asmjit/base/logger.cpp
@@ -45,8 +45,11 @@ void Logger::logFormat(uint32_t style, const char* fmt, ...) {
 
   va_list ap;
   va_start(ap, fmt);
-  len = vsnprintf(buf, 1023, fmt, ap);
+  len = vsnprintf(buf, sizeof(buf), fmt, ap);
   va_end(ap);
+
+  if (len >= sizeof(buf))
+    len = sizeof(buf) - 1;
 
   logString(style, buf, len);
 }


### PR DESCRIPTION
Fix invalid buffer length in logFormat()
    
When the buffer passed to vsnprintf() is too small it actually returns length of the string, not how many characters have been written to the buffer (which is limited by the buffer size).
    
So bound len by sizeof(buf) - 1 in logFormat().