### PR TITLE
Removed overloads with Mem operand for SSE xor instructions

### DIFF
--- a/src/app/test/genopcode.h
+++ b/src/app/test/genopcode.h
@@ -815,7 +815,6 @@ static void opcode(asmjit::X86Assembler& a) {
   a.unpcklps(xmm0, xmm7);
   a.unpcklps(xmm0, ptr_gp0);
   a.xorps(xmm0, xmm7);
-  a.xorps(xmm0, ptr_gp0);
 
   // SSE2.
   a.nop();
@@ -1065,7 +1064,6 @@ static void opcode(asmjit::X86Assembler& a) {
   a.unpcklpd(xmm0, xmm7);
   a.unpcklpd(xmm0, ptr_gp0);
   a.xorpd(xmm0, xmm7);
-  a.xorpd(xmm0, ptr_gp0);
 
   // SSE3.
   a.nop();
@@ -1965,13 +1963,9 @@ static void opcode(asmjit::X86Assembler& a) {
   a.vunpcklps(ymm0, ymm1, ymm2);
   a.vunpcklps(ymm0, ymm1, ptr_gp0);
   a.vxorpd(xmm0, xmm1, xmm2);
-  a.vxorpd(xmm0, xmm1, ptr_gp0);
   a.vxorpd(ymm0, ymm1, ymm2);
-  a.vxorpd(ymm0, ymm1, ptr_gp0);
   a.vxorps(xmm0, xmm1, xmm2);
-  a.vxorps(xmm0, xmm1, ptr_gp0);
   a.vxorps(ymm0, ymm1, ymm2);
-  a.vxorps(ymm0, ymm1, ptr_gp0);
   a.vzeroall();
   a.vzeroupper();
 

--- a/src/asmjit/x86/x86assembler.h
+++ b/src/asmjit/x86/x86assembler.h
@@ -2403,8 +2403,6 @@ struct ASMJIT_VCLASS X86Assembler : public Assembler {
 
   //! Packed SP-FP bitwise xor (SSE).
   INST_2x(xorps, kX86InstIdXorps, X86XmmReg, X86XmmReg)
-  //! \overload
-  INST_2x(xorps, kX86InstIdXorps, X86XmmReg, X86Mem)
 
   // --------------------------------------------------------------------------
   // [SSE2]
@@ -3036,8 +3034,6 @@ struct ASMJIT_VCLASS X86Assembler : public Assembler {
 
   //! Packed DP-FP bitwise xor (SSE2).
   INST_2x(xorpd, kX86InstIdXorpd, X86XmmReg, X86XmmReg)
-  //! \overload
-  INST_2x(xorpd, kX86InstIdXorpd, X86XmmReg, X86Mem)
 
   // --------------------------------------------------------------------------
   // [SSE3]
@@ -5203,20 +5199,12 @@ struct ASMJIT_VCLASS X86Assembler : public Assembler {
   //! Packed DP-FP bitwise xor (AVX).
   INST_3x(vxorpd, kX86InstIdVxorpd, X86XmmReg, X86XmmReg, X86XmmReg)
   //! \overload
-  INST_3x(vxorpd, kX86InstIdVxorpd, X86XmmReg, X86XmmReg, X86Mem)
-  //! \overload
   INST_3x(vxorpd, kX86InstIdVxorpd, X86YmmReg, X86YmmReg, X86YmmReg)
-  //! \overload
-  INST_3x(vxorpd, kX86InstIdVxorpd, X86YmmReg, X86YmmReg, X86Mem)
 
   //! Packed SP-FP bitwise xor (AVX).
   INST_3x(vxorps, kX86InstIdVxorps, X86XmmReg, X86XmmReg, X86XmmReg)
   //! \overload
-  INST_3x(vxorps, kX86InstIdVxorps, X86XmmReg, X86XmmReg, X86Mem)
-  //! \overload
   INST_3x(vxorps, kX86InstIdVxorps, X86YmmReg, X86YmmReg, X86YmmReg)
-  //! \overload
-  INST_3x(vxorps, kX86InstIdVxorps, X86YmmReg, X86YmmReg, X86Mem)
 
   //! Zero all Ymm registers.
   INST_0x(vzeroall, kX86InstIdVzeroall)


### PR DESCRIPTION
I can't see overloads with Mem operand for such instructions within Intel instruction set reference and it's fails in runtime.