### PR TITLE
CpuTicks:now(): fixed control flow for first-time call on OS Mac

### DIFF
--- a/src/asmjit/base/cputicks.cpp
+++ b/src/asmjit/base/cputicks.cpp
@@ -93,7 +93,7 @@ static mach_timebase_info_data_t CpuTicks_machTime;
 uint32_t CpuTicks::now() {
   // Initialize the first time CpuTicks::now() is called (See Apple's QA1398).
   if (CpuTicks_machTime.denom == 0) {
-    if (mach_timebase_info(&CpuTicks_machTime) != KERN_SUCCESS);
+    if (mach_timebase_info(&CpuTicks_machTime) != KERN_SUCCESS)
       return 0;
   }
 


### PR DESCRIPTION
On Mac OS, CpuTicks:now() returned 0 on the first call, no matter the return value from `mach_timebase_info()`. 

The calls to `now()` from the benchmark code were not really affected by this behavior, since time is measured multiple times there, and only the best run-time from multiple runs is kept. In other words, the way-too-long diff time computed based on the erroneous return value from `now()` is simply discarded.