### PR TITLE
TypeId::kId fix

### DIFF
--- a/src/asmjit/base/compiler.cpp
+++ b/src/asmjit/base/compiler.cpp
@@ -668,6 +668,7 @@ UNIT(base_compiler) {
 #endif  // __cplusplus >= 201103L
   }
 
+#if __cplusplus >= 201103L
   INFO("Checking TypeId::kId for fixed width integer types");
   {
     EXPECT(
@@ -689,6 +690,7 @@ UNIT(base_compiler) {
       TypeId<uint64_t>::kId == kVarTypeUInt64,
       "Unexpected Id for <uint64_t>");
   }
+#endif  // __cplusplus >= 201103L
 }
 #endif // ASMJIT_TEST
 #endif // ASMJIT_DOCGEN

--- a/src/asmjit/base/compiler.cpp
+++ b/src/asmjit/base/compiler.cpp
@@ -621,6 +621,78 @@ Assembler* Compiler::getAssembler() {
   return a;
 }
 
+// ============================================================================
+// [asmjit::Compiler - Test]
+// ============================================================================
+
+#if !defined(ASMJIT_DOCGEN)
+#if defined(ASMJIT_TEST)
+UNIT(base_compiler) {
+  INFO("Checking TypeId::kId for fundamental types");
+  {
+    EXPECT(
+      TypeId<short int>::kId == kVarTypeInt16 ||
+      TypeId<short int>::kId == kVarTypeInt32 ||
+      TypeId<short int>::kId == kVarTypeInt64,
+      "Unexpected Id for <short int>");
+    EXPECT(
+      TypeId<unsigned short int>::kId == kVarTypeUInt16 ||
+      TypeId<unsigned short int>::kId == kVarTypeUInt32 ||
+      TypeId<unsigned short int>::kId == kVarTypeUInt64,
+      "Unexpected Id for <unsigned short int>");
+    EXPECT(
+      TypeId<int>::kId == kVarTypeInt16 ||
+      TypeId<int>::kId == kVarTypeInt32 ||
+      TypeId<int>::kId == kVarTypeInt64,
+      "Unexpected Id for <int>");
+    EXPECT(
+      TypeId<unsigned int>::kId == kVarTypeUInt16 ||
+      TypeId<unsigned int>::kId == kVarTypeUInt32 ||
+      TypeId<unsigned int>::kId == kVarTypeUInt64,
+      "Unexpected Id for <unsigned int>");
+    EXPECT(
+      TypeId<long int>::kId == kVarTypeInt32 ||
+      TypeId<long int>::kId == kVarTypeInt64,
+      "Unexpected Id for <long int>");
+    EXPECT(
+      TypeId<unsigned long int>::kId == kVarTypeUInt32 ||
+      TypeId<unsigned long int>::kId == kVarTypeUInt64,
+      "Unexpected Id for <unsigned long int>");
+#if __cplusplus >= 201103L
+    EXPECT(
+      TypeId<long long int>::kId == kVarTypeInt64,
+      "Unexpected Id for <long long int>");
+    EXPECT(
+      TypeId<unsigned long long int>::kId == kVarTypeUInt64,
+      "Unexpected Id for <unsigned long long int>");
+#endif  // __cplusplus >= 201103L
+  }
+
+  INFO("Checking TypeId::kId for fixed width integer types");
+  {
+    EXPECT(
+      TypeId<int16_t>::kId == kVarTypeInt16,
+      "Unexpected Id for <int16_t>");
+    EXPECT(
+      TypeId<uint16_t>::kId == kVarTypeUInt16,
+      "Unexpected Id for <uint16_t>");
+    EXPECT(
+      TypeId<int32_t>::kId == kVarTypeInt32,
+      "Unexpected Id for <int32_t>");
+    EXPECT(
+      TypeId<uint32_t>::kId == kVarTypeUInt32,
+      "Unexpected Id for <uint32_t>");
+    EXPECT(
+      TypeId<int64_t>::kId == kVarTypeInt64,
+      "Unexpected Id for <int64_t>");
+    EXPECT(
+      TypeId<uint64_t>::kId == kVarTypeUInt64,
+      "Unexpected Id for <uint64_t>");
+  }
+}
+#endif // ASMJIT_TEST
+#endif // ASMJIT_DOCGEN
+
 } // asmjit namespace
 
 // [Api-End]

--- a/src/asmjit/base/compiler.h
+++ b/src/asmjit/base/compiler.h
@@ -21,6 +21,11 @@
 #include "../base/operand.h"
 #include "../base/zone.h"
 
+// [Dependencies - C]
+#if !defined(ASMJIT_DOCGEN)
+#include <limits.h>  // CHAR_BIT
+#endif
+
 // [Api-Begin]
 #include "../apibegin.h"
 
@@ -1189,15 +1194,46 @@ struct TypeId<T*> {
   struct TypeId<_T_> { enum { kId = _Id_ }; }
 
 ASMJIT_TYPE_ID(void         , kInvalidVar);
+
+#if __cplusplus >= 201103L
+static_assert(CHAR_BIT == 8, "sizeof(char) must be exactly 8 bits");
+#else
+typedef int static_assert_size_of_char_8_bits[CHAR_BIT == 8 ? 1 : -1];
+#endif
+
 ASMJIT_TYPE_ID(char         , IntTraits<char>::kIsSigned ? kVarTypeInt8 : kVarTypeUInt8);
 ASMJIT_TYPE_ID(signed char  , kVarTypeInt8);
 ASMJIT_TYPE_ID(unsigned char, kVarTypeUInt8);
-ASMJIT_TYPE_ID(int16_t      , kVarTypeInt16);
-ASMJIT_TYPE_ID(uint16_t     , kVarTypeUInt16);
-ASMJIT_TYPE_ID(int32_t      , kVarTypeInt32);
-ASMJIT_TYPE_ID(uint32_t     , kVarTypeUInt32);
-ASMJIT_TYPE_ID(int64_t      , kVarTypeInt64);
-ASMJIT_TYPE_ID(uint64_t     , kVarTypeUInt64);
+
+ASMJIT_TYPE_ID(short, \
+  IntTraits<short>::kIs16Bit ? kVarTypeInt16 \
+  : IntTraits<short>::kIs32Bit ? kVarTypeInt32 \
+  : kVarTypeInt64);
+ASMJIT_TYPE_ID(unsigned short, \
+  IntTraits<unsigned short>::kIs16Bit ? kVarTypeUInt16 \
+  : IntTraits<unsigned short>::kIs32Bit ? kVarTypeUInt32 \
+  : kVarTypeUInt64);
+ASMJIT_TYPE_ID(int, \
+  IntTraits<int>::kIs16Bit ? kVarTypeInt16 \
+  : IntTraits<int>::kIs32Bit ? kVarTypeInt32 \
+  : kVarTypeInt64);
+ASMJIT_TYPE_ID(unsigned, \
+  IntTraits<unsigned>::kIs16Bit ? kVarTypeUInt16 \
+  : IntTraits<unsigned>::kIs32Bit ? kVarTypeUInt32 \
+  : kVarTypeUInt64);
+ASMJIT_TYPE_ID(long, \
+  IntTraits<long>::kIs32Bit ? kVarTypeInt32 : kVarTypeInt64);
+ASMJIT_TYPE_ID(unsigned long, \
+  IntTraits<unsigned long>::kIs32Bit ? kVarTypeUInt32 : kVarTypeUInt64);
+
+#if __cplusplus >= 201103L
+ASMJIT_TYPE_ID(long long, kVarTypeInt64);
+ASMJIT_TYPE_ID(unsigned long long, kVarTypeUInt64);
+#else
+ASMJIT_TYPE_ID(int64_t, kVarTypeInt64);
+ASMJIT_TYPE_ID(uint64_t, kVarTypeUInt64);
+#endif
+
 ASMJIT_TYPE_ID(float        , kVarTypeFp32);
 ASMJIT_TYPE_ID(double       , kVarTypeFp64);
 

--- a/src/asmjit/base/compiler.h
+++ b/src/asmjit/base/compiler.h
@@ -1229,9 +1229,6 @@ ASMJIT_TYPE_ID(unsigned long, \
 #if __cplusplus >= 201103L
 ASMJIT_TYPE_ID(long long, kVarTypeInt64);
 ASMJIT_TYPE_ID(unsigned long long, kVarTypeUInt64);
-#else
-ASMJIT_TYPE_ID(int64_t, kVarTypeInt64);
-ASMJIT_TYPE_ID(uint64_t, kVarTypeUInt64);
 #endif
 
 ASMJIT_TYPE_ID(float        , kVarTypeFp32);


### PR DESCRIPTION
With these two commits, the project builds (again?) on Mac OS.

For this, I tried to provide overloads for `TypeId::kId` for each fundamental integer type available in standard C++. IMHO, this should be done for **each type** instead of for the fixed width integer types, since when such an overload is called for one of the "normal" integer types (`int`, `long`, etc.), there might be ambiguities or missing overloads. (This is quite a nuisance, because there is a wide range of possible sizes for the integer types.)

The cause of the project failing to build on Mac OS was that `size_t` seems to be a `typedef` for `long`, which might be the same length as `uint64_t`, but which is still a different type, see also [here](http://en.cppreference.com/w/cpp/language/types).

Also, as far as I know, the fixed width integer types as well as the type `long long` are only available since C++11, so I added an `#if` for that. However, just failing to provide overloads for the 64 bit types might or might not be problematic, given that the type `uint64_t` is used extensively elsewhere throughout the project, I simply do not know yet.

I added an assert that requires the `char` types to be exactly 8 bits, since otherwise the way `kId` are set does not make sense.

**Note:** Unfortunately, according to the CI server, a test crashes on Mac OS for the 32 bit builds (both Debug and Release). I'm not yet familiar with this project, and I have not yet been able to track down the cause of the crash.