### PR TITLE
fixed issues with build type and flag setting and propagation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -98,30 +98,19 @@ EndIf()
 If("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
   Message("-- Using GCC")
 
-  Set(ASMJIT_CFLAGS
-    -fno-exceptions)
-  Set(ASMJIT_CFLAGS_DBG
-    -DASMJIT_DEBUG -O0)
+  Set(ASMJIT_CFLAGS "-fno-exceptions")
+  Set(ASMJIT_CFLAGS_DBG "-DASMJIT_DEBUG")
   Set(ASMJIT_CFLAGS_REL
-    -DASMJIT_RELEASE -O2
-    -finline-functions
-    -fomit-frame-pointer
-    -fmerge-all-constants
-    -fno-keep-static-consts)
+    "-DASMJIT_RELEASE -finline-functions -fomit-frame-pointer -fmerge-all-constants -fno-keep-static-consts")
 EndIf()
 
 # Clang.
 If("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
   Message("-- Using Clang")
 
-  Set(ASMJIT_CFLAGS
-    -fno-exceptions)
-  Set(ASMJIT_CFLAGS_DBG
-    -DASMJIT_DEBUG -O0)
-  Set(ASMJIT_CFLAGS_REL
-    -DASMJIT_RELEASE -O2
-    -fomit-frame-pointer
-    -fmerge-all-constants)
+  Set(ASMJIT_CFLAGS "-fno-exceptions")
+  Set(ASMJIT_CFLAGS_DBG "-DASMJIT_DEBUG")
+  Set(ASMJIT_CFLAGS_REL "-DASMJIT_RELEASE -fomit-frame-pointer -fmerge-all-constants")
 EndIf()
 
 # Use Unicode by default on Windows target.
@@ -144,8 +133,8 @@ IF(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
   LIST(APPEND ASMJIT_DEPS rt)
 ENDIF()
 
-Set(ASMJIT_CFLAGS_DBG ${ASMJIT_CFLAGS} ${ASMJIT_CFLAGS_DBG})
-Set(ASMJIT_CFLAGS_REL ${ASMJIT_CFLAGS} ${ASMJIT_CFLAGS_REL})
+Set(ASMJIT_CFLAGS_DBG "${ASMJIT_CFLAGS} ${ASMJIT_CFLAGS_DBG}")
+Set(ASMJIT_CFLAGS_REL "${ASMJIT_CFLAGS} ${ASMJIT_CFLAGS_REL}")
 
 # =============================================================================
 # [AsmJit - Macros]
@@ -184,11 +173,11 @@ Macro(AsmJit_AddLibrary in_name in_src in_deps in_cflags in_cflags_dbg in_cflags
   Target_Link_Libraries(${in_name} ${in_deps})
 
   # Compiler Flags.
-  If(${CMAKE_BUILD_TYPE})
+  If(DEFINED CMAKE_BUILD_TYPE)
     If(${CMAKE_BUILD_TYPE} MATCHES "Debug")
-      Set_Target_Properties(${in_name} PROPERTIES COMPILE_FLAGS ${in_cflags} ${in_cflags_dbg})
+      Set_Target_Properties(${in_name} PROPERTIES COMPILE_FLAGS ${in_cflags_dbg})
     Else()
-      Set_Target_Properties(${in_name} PROPERTIES COMPILE_FLAGS ${in_cflags} ${in_cflags_rel})
+      Set_Target_Properties(${in_name} PROPERTIES COMPILE_FLAGS ${in_cflags_rel})
     EndIf()
   Else()
     Target_Compile_Options(${in_name} PUBLIC ${in_cflags}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -314,18 +314,22 @@ If(ASMJIT_BUILD_TEST)
   AsmJit_AddSource(ASMJIT_TEST_SRC test asmjit_test_unit.cpp broken.cpp broken.h)
 
   Set(ASMJIT_TEST_CFLAGS
-    ${ASMJIT_CFLAGS}
-    ${ASMJIT_DEFINE}ASMJIT_STATIC
-    ${ASMJIT_DEFINE}ASMJIT_TEST)
+    "${ASMJIT_CFLAGS} ${ASMJIT_DEFINE}ASMJIT_STATIC ${ASMJIT_DEFINE}ASMJIT_TEST")
 
   Add_Executable(asmjit_test_unit ${ASMJIT_SRC} ${ASMJIT_TEST_SRC})
   Target_Link_Libraries(asmjit_test_unit ${ASMJIT_DEPS})
 
-  If(${CMAKE_BUILD_TYPE})
+  If(CMAKE_BUILD_TYPE)
     If(${CMAKE_BUILD_TYPE} MATCHES "Debug")
-      Set_Target_Properties(asmjit_test_unit PROPERTIES COMPILE_FLAGS ${ASMJIT_TEST_CFLAGS} ${ASMJIT_CFLAGS_DBG})
+      Set_Property(
+        TARGET asmjit_test_unit
+        APPEND_STRING
+        PROPERTY COMPILE_FLAGS "${ASMJIT_TEST_CFLAGS} ${ASMJIT_CFLAGS_DBG}")
     Else()
-      Set_Target_Properties(asmjit_test_unit PROPERTIES COMPILE_FLAGS ${ASMJIT_TEST_CFLAGS} ${ASMJIT_CFLAGS_REL})
+      Set_Property(
+        TARGET asmjit_test_unit
+        APPEND_STRING
+        PROPERTY COMPILE_FLAGS "${ASMJIT_TEST_CFLAGS} ${ASMJIT_CFLAGS_REL}")
     EndIf()
   Else()
     Target_Compile_Options(asmjit_test_unit PUBLIC ${ASMJIT_TEST_CFLAGS}


### PR DESCRIPTION
This should fix Issue #103 for single-configuration generators. I tested it on Mac using clang.

Note that I deleted some options regarding Debug/Release, since cmake appears to be smart enough to figure those out by itself, see also [here](http://voices.canonical.com/jussi.pakkanen/2013/03/26/a-list-of-common-cmake-antipatterns/).

Mostly, the fix is about adding quoting to the variable setters, and properly checking if CMAKE_BUILD_TYPE is defined.

I tried to honor your style (max characters per line), but it seems to be necessary for them to be there on one line.

I seems to be unnecessary to also set `${in_cflags}`, since they are added in a `set()` a couple of lines above. 